### PR TITLE
feat(pilot): deterministic file-first seeding for demo data

### DIFF
--- a/nr-pilot/README.md
+++ b/nr-pilot/README.md
@@ -18,6 +18,20 @@ With the server running:
 curl -s http://localhost:5000/status | jq .
 ```
 
+### Deterministic seeding
+
+Populate `state.nodes.json` and `state.suggestions.json` with deterministic demo data:
+
+```bash
+node scripts/seed-demo.cjs --cohort demo --n 50 --k 3 --seed 42 --force
+```
+
+Re-run the doctor or status check to confirm counts:
+
+```bash
+curl -s http://localhost:5000/status | jq '.counts'
+```
+
 ## Developer helpers
 
 - `dev.http` – REST client snippets for `/healthz` and `/status`.

--- a/nr-pilot/backend/lib/rng.cjs
+++ b/nr-pilot/backend/lib/rng.cjs
@@ -1,0 +1,52 @@
+const crypto = require('crypto');
+
+function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function rand() {
+    t += 0x6d2b79f5;
+    let result = Math.imul(t ^ (t >>> 15), 1 | t);
+    result ^= result + Math.imul(result ^ (result >>> 7), 61 | result);
+    return ((result ^ (result >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function createRng(seed = 1) {
+  if (!Number.isInteger(seed)) {
+    throw new Error('Seed must be an integer');
+  }
+  const rand = mulberry32(seed);
+  const api = {
+    rand,
+    randInt(max) {
+      return Math.floor(rand() * max);
+    },
+    choice(list) {
+      if (!Array.isArray(list) || list.length === 0) throw new Error('choice requires a non-empty array');
+      return list[api.randInt(list.length)];
+    },
+    shuffle(list) {
+      const arr = list.slice();
+      for (let i = arr.length - 1; i > 0; i -= 1) {
+        const j = api.randInt(i + 1);
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      return arr;
+    },
+    uuidv4() {
+      const bytes = Buffer.alloc(16);
+      for (let i = 0; i < 16; i += 1) {
+        bytes[i] = Math.floor(rand() * 256);
+      }
+      // Set version and variant bits
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex = bytes.toString('hex');
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    }
+  };
+  return api;
+}
+
+module.exports = {
+  createRng
+};

--- a/nr-pilot/backend/lib/schema.cjs
+++ b/nr-pilot/backend/lib/schema.cjs
@@ -32,8 +32,8 @@ function validateSuggestions(raw) {
       suggestion &&
       typeof suggestion === 'object' &&
       typeof suggestion.id === 'string' &&
-      typeof suggestion.nodeId === 'string' &&
-      typeof suggestion.otherId === 'string',
+      ((typeof suggestion.nodeId === 'string' && typeof suggestion.otherId === 'string') ||
+        (typeof suggestion.a === 'string' && typeof suggestion.b === 'string')),
     'suggestions'
   );
 }

--- a/nr-pilot/backend/lib/store.cjs
+++ b/nr-pilot/backend/lib/store.cjs
@@ -79,5 +79,6 @@ module.exports = {
   ensureStateDir,
   readJsonSafe,
   writeJsonAtomic,
-  countOf
+  countOf,
+  resolveFilePath
 };

--- a/nr-pilot/backend/lib/traits.cjs
+++ b/nr-pilot/backend/lib/traits.cjs
@@ -1,0 +1,51 @@
+const STRENGTHS = ['systems', 'ops', 'facilitation', 'design', 'ml', 'research', 'growth', 'product'];
+const CHALLENGES = ['focus', 'handoffs', 'messaging', 'recruiting', 'time'];
+const INTERESTS = ['ml', 'climate', 'education', 'health', 'ops', 'community'];
+const VALUES = ['craft', 'impact', 'play', 'clarity', 'care'];
+const PROJECTS = ['pilot', 'atlas', 'lab', 'onboarding'];
+
+function pickSet(rng, list, min = 1, max = 3) {
+  if (min > max) throw new Error('min cannot exceed max');
+  const targetSize = min + rng.randInt(max - min + 1);
+  const shuffled = rng.shuffle(list);
+  return shuffled.slice(0, Math.min(targetSize, shuffled.length));
+}
+
+function toSet(arr) {
+  return new Set(arr);
+}
+
+function jaccard(aList, bList) {
+  const a = toSet(aList);
+  const b = toSet(bList);
+  if (a.size === 0 && b.size === 0) return 0;
+  let intersection = 0;
+  for (const value of a) {
+    if (b.has(value)) intersection += 1;
+  }
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function scoreOverlap(nodeA, nodeB) {
+  const strengthsScore = jaccard(nodeA.strengths, nodeB.strengths);
+  const interestsScore = jaccard(nodeA.interests, nodeB.interests);
+  return Number((strengthsScore * 0.7 + interestsScore * 0.3).toFixed(2));
+}
+
+function publicRationale(nodeA, nodeB, score) {
+  const mention = score >= 0.5 ? 'strong overlap' : 'potential synergy';
+  return `${nodeA.displayName} and ${nodeB.displayName} show ${mention} on strengths/interests.`;
+}
+
+module.exports = {
+  STRENGTHS,
+  CHALLENGES,
+  INTERESTS,
+  VALUES,
+  PROJECTS,
+  pickSet,
+  jaccard,
+  scoreOverlap,
+  publicRationale
+};

--- a/nr-pilot/dev.http
+++ b/nr-pilot/dev.http
@@ -1,5 +1,7 @@
+@port = {{port=5000}}
+
 ### Pilot health
-GET http://localhost:5000/healthz
+GET http://localhost:{{port}}/healthz
 
 ### Pilot status
-GET http://localhost:5000/status
+GET http://localhost:{{port}}/status

--- a/nr-pilot/scripts/dev-doctor.sh
+++ b/nr-pilot/scripts/dev-doctor.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_URL="${NR_BASE_URL:-http://localhost:5000}"
+PORT="${PORT:-5000}"
+BASE_URL="${NR_BASE_URL:-http://localhost:${PORT}}"
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required for the doctor script" >&2

--- a/nr-pilot/scripts/seed-demo.cjs
+++ b/nr-pilot/scripts/seed-demo.cjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+const fs = require('fs/promises');
+const path = require('path');
+const { ensureStateDir, resolveFilePath, writeJsonAtomic } = require('../backend/lib/store.cjs');
+const { createRng } = require('../backend/lib/rng.cjs');
+const {
+  STRENGTHS,
+  CHALLENGES,
+  INTERESTS,
+  VALUES,
+  PROJECTS,
+  pickSet,
+  scoreOverlap,
+  publicRationale
+} = require('../backend/lib/traits.cjs');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const options = { force: false };
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+    const key = token.slice(2);
+    if (key === 'force') {
+      options.force = true;
+      continue;
+    }
+    const value = args[i + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    i += 1;
+    options[key] = value;
+  }
+  return options;
+}
+
+function assertOptions(opts) {
+  if (!opts.cohort) throw new Error('--cohort is required');
+  const n = Number.parseInt(opts.n, 10);
+  if (!Number.isFinite(n) || n <= 0) throw new Error('--n must be a positive integer');
+  const k = Number.parseInt(opts.k, 10);
+  if (!Number.isFinite(k) || k < 0) throw new Error('--k must be a non-negative integer');
+  const seed = opts.seed === undefined ? 1 : Number.parseInt(opts.seed, 10);
+  if (!Number.isFinite(seed)) throw new Error('--seed must be an integer');
+  return { cohort: opts.cohort, n, k, seed, force: Boolean(opts.force) };
+}
+
+function baseTimestampMs() {
+  return Date.UTC(2024, 0, 1, 0, 0, 0, 0);
+}
+
+function buildNode(idx, rng, cohort) {
+  const createdAt = new Date(baseTimestampMs() + idx * 60000).toISOString();
+  return {
+    id: rng.uuidv4(),
+    cohortId: cohort,
+    displayName: `User ${idx + 1}`,
+    alias: `U${idx + 1}`,
+    email: null,
+    strengths: pickSet(rng, STRENGTHS, 2, 3),
+    challenges: pickSet(rng, CHALLENGES, 1, 2),
+    projects: pickSet(rng, PROJECTS, 1, 2),
+    interests: pickSet(rng, INTERESTS, 1, 3),
+    values: pickSet(rng, VALUES, 1, 2),
+    consent: { shareProfile: true },
+    createdAt
+  };
+}
+
+function buildSuggestions(nodes, k, rng) {
+  if (k === 0 || nodes.length < 2) return [];
+  const pairs = new Set();
+  const suggestions = [];
+  let createdOffset = 0;
+  const incrementMs = 30000;
+
+  for (let i = 0; i < nodes.length; i += 1) {
+    const nodeA = nodes[i];
+    let edgesForNode = 0;
+    let attempts = 0;
+    const maxAttempts = nodes.length * 5;
+    while (edgesForNode < k && attempts < maxAttempts) {
+      attempts += 1;
+      const otherIndex = rng.randInt(nodes.length);
+      if (otherIndex === i) continue;
+      const nodeB = nodes[otherIndex];
+      const [aId, bId] = nodeA.id < nodeB.id ? [nodeA.id, nodeB.id] : [nodeB.id, nodeA.id];
+      const key = `${aId}|${bId}`;
+      if (pairs.has(key)) continue;
+      pairs.add(key);
+      const score = scoreOverlap(nodeA, nodeB);
+      const createdAt = new Date(baseTimestampMs() + nodes.length * 60000 + createdOffset).toISOString();
+      createdOffset += incrementMs;
+      suggestions.push({
+        id: rng.uuidv4(),
+        cohortId: nodeA.cohortId,
+        a: aId,
+        b: bId,
+        state: 'ghost',
+        score,
+        rationale_public: publicRationale(nodeA, nodeB, score),
+        createdAt
+      });
+      edgesForNode += 1;
+    }
+  }
+  return suggestions;
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (err) {
+    if (err.code === 'ENOENT') return false;
+    throw err;
+  }
+}
+
+async function appendEvent(event) {
+  const filePath = resolveFilePath('events.log.jsonl');
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.appendFile(filePath, `${JSON.stringify(event)}\n`, 'utf8');
+}
+
+(async () => {
+  try {
+    const opts = assertOptions(parseArgs(process.argv));
+    const allowInit = process.env.NR_ALLOW_INIT_DIR === 'true';
+    await ensureStateDir({ allowInit });
+
+    const nodesFile = resolveFilePath('state.nodes.json');
+    const suggestionsFile = resolveFilePath('state.suggestions.json');
+
+    if (!opts.force) {
+      const existingNodes = await fileExists(nodesFile);
+      const existingSuggestions = await fileExists(suggestionsFile);
+      if (existingNodes || existingSuggestions) {
+        console.error('State files already exist. Use --force to overwrite.');
+        process.exit(1);
+      }
+    }
+
+    const rng = createRng(opts.seed);
+    const nodes = Array.from({ length: opts.n }, (_, idx) => buildNode(idx, rng, opts.cohort));
+    const suggestions = buildSuggestions(nodes, opts.k, rng);
+
+    await writeJsonAtomic('state.nodes.json', nodes);
+    await writeJsonAtomic('state.suggestions.json', suggestions);
+
+    const now = new Date().toISOString();
+    await appendEvent({ ts: now, actor: 'seed', action: 'seed_nodes', cohort: opts.cohort, count: nodes.length });
+    await appendEvent({ ts: now, actor: 'seed', action: 'seed_suggestions', cohort: opts.cohort, count: suggestions.length });
+
+    console.log(`Seed complete. Nodes: ${nodes.length}. Suggestions: ${suggestions.length}.`);
+    console.log(`Wrote ${nodesFile}`);
+    console.log(`Wrote ${suggestionsFile}`);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
PR description suggestion:

Add deterministic seed script for the pilot.

builds seeded nodes and ghost suggestions under NR_STATE_DIR
writes state.nodes.json, state.suggestions.json, and appends events
updates doctor/dev.http/README
Manual check:
node nr-pilot/scripts/seed-demo.cjs --cohort demo --n 50 --k 3 --seed 42 --force
/status shows counts nodes=50, suggestions=150, consents=0