### PR TITLE
feat(pilot): add admin review and consent endpoints

### DIFF
--- a/nr-pilot/README.md
+++ b/nr-pilot/README.md
@@ -32,6 +32,32 @@ Re-run the doctor or status check to confirm counts:
 curl -s http://localhost:5000/status | jq '.counts'
 ```
 
+### Admin utilities
+
+- List pending suggestions:
+
+  ```bash
+  curl -s http://localhost:5000/admin/pending | jq '.data | length'
+  ```
+
+- Approve and advance consent state:
+
+  ```bash
+  curl -s -X POST http://localhost:5000/admin/approve \\
+    -H 'content-type: application/json' \\
+    -d '{"ids":["<suggestion-id>"]}'
+
+  curl -s -X POST http://localhost:5000/consent \\
+    -H 'content-type: application/json' \\
+    -d '{"ids":["<suggestion-id>"],"action":"accept","userId":"userA"}'
+  ```
+
+- Reset suggestions while keeping nodes intact:
+
+  ```bash
+  curl -s -X POST http://localhost:5000/admin/reset | jq .
+  ```
+
 ## Developer helpers
 
 - `dev.http` – REST client snippets for `/healthz` and `/status`.

--- a/nr-pilot/backend/index.cjs
+++ b/nr-pilot/backend/index.cjs
@@ -25,6 +25,7 @@ async function main() {
 
   fastify.get('/healthz', async () => ({ ok: true }));
   fastify.register(require('./routes/status.cjs'));
+  fastify.register(require('./routes/admin.cjs'));
 
   try {
     await fastify.listen({ port, host });

--- a/nr-pilot/backend/lib/store.cjs
+++ b/nr-pilot/backend/lib/store.cjs
@@ -74,11 +74,19 @@ async function countOf(fileName) {
   return Array.isArray(data) ? data.length : 0;
 }
 
+async function appendJsonLine(fileName, entry) {
+  const filePath = resolveFilePath(fileName);
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, 'utf8');
+}
+
 module.exports = {
   getStateDir,
   ensureStateDir,
   readJsonSafe,
   writeJsonAtomic,
   countOf,
-  resolveFilePath
+  resolveFilePath,
+  appendJsonLine
 };

--- a/nr-pilot/backend/routes/admin.cjs
+++ b/nr-pilot/backend/routes/admin.cjs
@@ -1,0 +1,142 @@
+const { readJsonSafe, writeJsonAtomic, appendJsonLine } = require('../lib/store.cjs');
+const { validateSuggestions } = require('../lib/schema.cjs');
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function matchesEnumerated(field, allowedValues) {
+  return (suggestion, matchValues) => {
+    if (!Array.isArray(matchValues) || matchValues.length === 0) return false;
+    if (typeof suggestion[field] === 'string') {
+      return matchValues.includes(suggestion[field]);
+    }
+    return false;
+  };
+}
+
+const filterMatchers = {
+  ids: (suggestion, ids) => Array.isArray(ids) && ids.includes(suggestion.id),
+  cohortIds: matchesEnumerated('cohortId'),
+  states: matchesEnumerated('state')
+};
+
+function filterSuggestions(suggestions, filter = {}) {
+  if (!filter || Object.keys(filter).length === 0) return suggestions;
+  return suggestions.filter((suggestion) =>
+    Object.entries(filter).every(([key, value]) => {
+      const matcher = filterMatchers[key];
+      if (!matcher) return true;
+      return matcher(suggestion, value);
+    })
+  );
+}
+
+async function loadSuggestions() {
+  const raw = await readJsonSafe('state.suggestions.json', []);
+  return validateSuggestions(raw);
+}
+
+async function saveSuggestions(next) {
+  await writeJsonAtomic('state.suggestions.json', next);
+}
+
+async function appendEvent(action, payload = {}) {
+  const event = {
+    ts: nowIso(),
+    actor: 'admin',
+    action,
+    ...payload
+  };
+  await appendJsonLine('events.log.jsonl', event);
+}
+
+module.exports = async function registerAdminRoutes(fastify) {
+  fastify.get('/admin/pending', async (request, reply) => {
+    const suggestions = await loadSuggestions();
+    const pending = filterSuggestions(suggestions, {
+      states: request.query.states || ['ghost', 'admin_approved']
+    });
+    return { ok: true, data: pending };
+  });
+
+  fastify.post('/admin/approve', async (request, reply) => {
+    const ids = request.body && request.body.ids;
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return reply.status(400).send({ ok: false, error: { message: 'ids array is required' } });
+    }
+    const suggestions = await loadSuggestions();
+    let updates = 0;
+    const next = suggestions.map((suggestion) => {
+      if (ids.includes(suggestion.id) && suggestion.state === 'ghost') {
+        updates += 1;
+        return { ...suggestion, state: 'admin_approved', updatedAt: nowIso() };
+      }
+      return suggestion;
+    });
+    await saveSuggestions(next);
+    await appendEvent('approve', { ids, count: updates });
+    return { ok: true, count: updates };
+  });
+
+  fastify.post('/consent', async (request, reply) => {
+    const payload = request.body || {};
+    const ids = Array.isArray(payload.ids) ? payload.ids : [payload.id].filter(Boolean);
+    if (ids.length === 0) {
+      return reply.status(400).send({ ok: false, error: { message: 'id(s) required' } });
+    }
+    if (!['accept', 'decline'].includes(payload.action)) {
+      return reply.status(400).send({ ok: false, error: { message: 'action must be accept or decline' } });
+    }
+
+    const suggestions = await loadSuggestions();
+    let updates = 0;
+    const next = suggestions.map((suggestion) => {
+      if (!ids.includes(suggestion.id) || suggestion.state === 'solid' || suggestion.state === 'declined') {
+        return suggestion;
+      }
+      if (payload.action === 'accept') {
+        const acceptance = new Set(Array.isArray(suggestion.acceptedBy) ? suggestion.acceptedBy : []);
+        acceptance.add(payload.userId || 'unknown');
+        if (acceptance.size >= 2) {
+          updates += 1;
+          return {
+            ...suggestion,
+            state: 'solid',
+            acceptedBy: Array.from(acceptance),
+            consented: true,
+            finalizedAt: nowIso()
+          };
+        }
+        updates += 1;
+        return {
+          ...suggestion,
+          state: 'admin_approved',
+          acceptedBy: Array.from(acceptance),
+          updatedAt: nowIso()
+        };
+      }
+
+      updates += 1;
+      return {
+        ...suggestion,
+        state: 'declined',
+        declinedBy: payload.userId || 'unknown',
+        updatedAt: nowIso()
+      };
+    });
+
+    await saveSuggestions(next);
+    await appendEvent('consent', { ids, action: payload.action, count: updates });
+    return { ok: true, count: updates };
+  });
+
+  fastify.post('/admin/reset', async (request, reply) => {
+    const suggestions = await readJsonSafe('state.suggestions.json', []);
+    const nodes = await readJsonSafe('state.nodes.json', []);
+    const summary = { nodes: nodes.length, suggestions: suggestions.length };
+    await writeJsonAtomic('state.suggestions.json', []);
+    await appendEvent('reset', summary);
+    return { ok: true, message: 'suggestions cleared', summary };
+  });
+};

--- a/nr-pilot/dev.http
+++ b/nr-pilot/dev.http
@@ -5,3 +5,27 @@ GET http://localhost:{{port}}/healthz
 
 ### Pilot status
 GET http://localhost:{{port}}/status
+
+### Admin pending (optional query: states=ghost&states=admin_approved)
+GET http://localhost:{{port}}/admin/pending
+
+### Admin approve (edit id)
+POST http://localhost:{{port}}/admin/approve
+content-type: application/json
+
+{
+  "ids": ["<suggestion-id>"]
+}
+
+### Consent decision (accept/decline)
+POST http://localhost:{{port}}/consent
+content-type: application/json
+
+{
+  "ids": ["<suggestion-id>"],
+  "action": "accept",
+  "userId": "userA"
+}
+
+### Reset suggestions
+POST http://localhost:{{port}}/admin/reset

--- a/nr-pilot/scripts/seed-demo.cjs
+++ b/nr-pilot/scripts/seed-demo.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const fs = require('fs/promises');
 const path = require('path');
-const { ensureStateDir, resolveFilePath, writeJsonAtomic } = require('../backend/lib/store.cjs');
+const { ensureStateDir, resolveFilePath, writeJsonAtomic, appendJsonLine } = require('../backend/lib/store.cjs');
 const { createRng } = require('../backend/lib/rng.cjs');
 const {
   STRENGTHS,
@@ -121,9 +121,7 @@ async function fileExists(filePath) {
 }
 
 async function appendEvent(event) {
-  const filePath = resolveFilePath('events.log.jsonl');
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.appendFile(filePath, `${JSON.stringify(event)}\n`, 'utf8');
+  await appendJsonLine('events.log.jsonl', event);
 }
 
 (async () => {


### PR DESCRIPTION
eat(pilot): add admin review + consent endpoints
• /admin/pending, /admin/approve, /consent, /admin/reset wired through the atomic store and event log
• doctor/dev.http/README updated with the new flows
• Manual run: seed demo (10×2) → approve → consent (two accept + one decline) → reset → /status shows suggestions 0