### PR TITLE
feat(api): add authenticated submission success path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The Fastify server will start on port `4000` (configurable via `API_PORT`). A he
 pnpm --filter @apn/api test
 ```
 
+Set `APN_TEST_JWT` (or `API_TEST_JWT`) to a confirmed Supabase user token to exercise the authenticated submission path during the test run.
+
 ## Repository layout
 
 - `apps/api` — Fastify + Supabase service with authentication middleware and health check route.

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -28,4 +28,43 @@ describe('API basics', () => {
     });
     expect(res.statusCode).toBe(401);
   });
+
+  it('accepts submissions when authorized', async () => {
+    const token = process.env.APN_TEST_JWT ?? process.env.API_TEST_JWT;
+    if (!token) {
+      // Skip when a real Supabase user token is not configured.
+      expect(true).toBe(true);
+      return;
+    }
+
+    const roomName = `vitest-room-${Date.now()}`;
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/rooms',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json'
+      },
+      payload: { name: roomName }
+    });
+
+    expect([200, 201]).toContain(createRes.statusCode);
+    const createBody = createRes.json() as { ok: boolean; data: { id: string } };
+    expect(createBody.ok).toBe(true);
+
+    const submissionRes = await app.inject({
+      method: 'POST',
+      url: `/rooms/${roomName}/submissions`,
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json'
+      },
+      payload: { payload: { msg: 'vitest', ts: new Date().toISOString() } }
+    });
+
+    expect(submissionRes.statusCode).toBe(201);
+    const submissionBody = submissionRes.json() as { ok: boolean; data?: { roomId: string } };
+    expect(submissionBody.ok).toBe(true);
+    expect(submissionBody.data?.roomId).toBe(createBody.data.id);
+  });
 });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -4,6 +4,7 @@ import { createEnv } from './env.js';
 import { createSupabaseClient } from './supabase.js';
 import authPlugin from './plugins/supabase-auth.js';
 import { registerHealthRoutes } from './routes/health.js';
+import registerRoomsRoutes from './routes/rooms.js';
 
 export const buildServer = (): FastifyInstance => {
   const env = createEnv();
@@ -18,6 +19,7 @@ export const buildServer = (): FastifyInstance => {
 
   fastify.register(authPlugin);
   fastify.register(registerHealthRoutes);
+  fastify.register(registerRoomsRoutes);
 
   return fastify;
 };


### PR DESCRIPTION
feat(api): add authenticated submission success path

enforce room/list/create/submission endpoints via Supabase auth (owner-id scoping)
extend Vitest suite to hit /rooms/:slug/submissions with a real JWT when available
update doctor/dev.http/README to cover the auth flow
Manual verification:
APN_JWT=… ./scripts/dev-doctor.sh → 401 unauth → 201 auth, room/submission created
Vitest run with APN_TEST_JWT set passes all three tests